### PR TITLE
Breakpoint command and make REPL infallible

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ view - prints the vram
 Usage examples:
 
 ```
-load roms/pong.ch8 # loads a file located at roms/pong.ch8 to CPU
+load roms/pong.ch8 # loads a file located at roms/pong.ch8 to a new CPU
 l roms/pong.ch8    # same as above
 
 run              # runs the CPU until it crashes

--- a/README.md
+++ b/README.md
@@ -34,6 +34,35 @@ execute <0xNNNN> - executes a hex command on the CPU
 view - prints the vram
 ```
 
+Usage examples:
+
+```
+load roms/pong.ch8 # loads a file located at roms/pong.ch8 to CPU
+l roms/pong.ch8    # same as above
+
+run              # runs the CPU until it crashes
+r                # same as above
+
+step             # steps one instruction
+s                # same as above
+
+s 100            # steps 0x100 instructions
+s 0x100          # same as above 
+
+
+debug            # prints the current state of the CPU
+d                # same as above
+
+breakpoint 0x200 # sets a breakpoint when pc @ 0x200
+b 0x200          # same as above
+
+execute 0x00e0   # executes the command 0x00e0 on the CPU 
+e 0x00e0         # same as above
+
+view             # prints the current state of the vram
+v                # same as above
+```
+
 # References
 
 - [Guide to making a CHIP-8 emulator](https://tobiasvl.github.io/blog/write-a-chip-8-emulator/#display)

--- a/src/bin/repl.rs
+++ b/src/bin/repl.rs
@@ -169,9 +169,9 @@ fn main() {
                     breakpoints.retain(|&x| x != addr);
                 } else {
                     println!("Adding breakpoint when the pc is {:#X}", addr);
+                    breakpoints.push(addr);
                 }
 
-                breakpoints.push(addr);
             }
 
             _ => {}

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -8,6 +8,7 @@ const WIDTH: usize = 64;
 const HEIGHT_U8: u8 = 32;
 const WIDTH_U8: u8 = 64;
 
+#[derive(Debug, Clone)]
 pub struct CPU {
     ram: Memory,                   // 4kB of RAM
     vram: [[bool; HEIGHT]; WIDTH], //vram containing pixel values, stored in column-major order
@@ -232,5 +233,9 @@ impl CPU {
             print!("-");
         }
         println!();
+    }
+
+    pub fn program_counter(&self) -> u16 {
+        u12::into(self.pc)
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -5,6 +5,7 @@ use ux::*;
 const SIZE: usize = 4096;
 const PROGRAM_START: usize = 0x200;
 
+#[derive(Debug, Clone)]
 pub struct Memory {
     mem: [u8; SIZE],
 }


### PR DESCRIPTION
- Breakpoints can now be added and removed which check on the program counter (pc)
- REPL should gracefully continue invalid input or internal errors
- Step command can now optionally accept a hexadecimal number